### PR TITLE
Enable reordering of answers in vrageneditor

### DIFF
--- a/aitutor.css
+++ b/aitutor.css
@@ -68,6 +68,96 @@ input, textarea, select {
   box-sizing: border-box;
 }
 
+.answer-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+  width: 100%;
+  max-width: 720px;
+}
+
+.answer-input {
+  flex: 1;
+  width: 100%;
+  margin: 0;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.answer-row--correct .answer-input {
+  background: #f5fdf9;
+  border-color: #87d9ad;
+}
+
+.answer-controls {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.answer-sort-button {
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border-radius: 50%;
+  font-size: 1.2rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.answer-checkbox {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.answer-checkbox input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.answer-checkbox-box {
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
+  border: 2px solid #bcd0ee;
+  background: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: transparent;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.answer-checkbox:hover .answer-checkbox-box {
+  border-color: #9cbce6;
+}
+
+.answer-checkbox input:checked + .answer-checkbox-box {
+  background: #4cc990;
+  border-color: #4cc990;
+  color: #fff;
+  box-shadow: 0 6px 16px rgba(76, 201, 144, 0.2);
+}
+
+.answer-checkbox input:focus-visible + .answer-checkbox-box {
+  box-shadow: 0 0 0 3px rgba(76, 201, 144, 0.35);
+}
+
 textarea {
   width: 100%;
   max-width: 680px;
@@ -76,7 +166,8 @@ textarea {
   margin-bottom: 12px;
 }
 
-input[type="text"], input[type="number"] {
+input[type="text"]:not(.answer-input),
+input[type="number"]:not(.answer-input) {
   width: 220px;
 }
 
@@ -133,6 +224,15 @@ label {
     flex-direction: column;
     align-items: flex-start;
     gap: 2px;
+  }
+  .answer-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+  .answer-controls {
+    justify-content: flex-end;
+    width: 100%;
   }
 }
 

--- a/aitutor.css
+++ b/aitutor.css
@@ -69,9 +69,10 @@ input, textarea, select {
 }
 
 .answer-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(36px, auto) minmax(40px, auto) minmax(40px, auto);
   align-items: center;
-  gap: 16px;
+  column-gap: 16px;
   margin-bottom: 16px;
   width: 100%;
   max-width: 720px;
@@ -89,10 +90,16 @@ input, textarea, select {
   border-color: #87d9ad;
 }
 
-.answer-controls {
-  display: flex;
-  gap: 8px;
-  margin-left: auto;
+.answer-checkbox {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  margin: 0;
+  justify-self: center;
 }
 
 .answer-sort-button {
@@ -106,16 +113,7 @@ input, textarea, select {
   align-items: center;
   justify-content: center;
   margin: 0;
-}
-
-.answer-checkbox {
-  position: relative;
-  width: 36px;
-  height: 36px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
+  justify-self: center;
 }
 
 .answer-checkbox input {
@@ -156,6 +154,13 @@ input, textarea, select {
 
 .answer-checkbox input:focus-visible + .answer-checkbox-box {
   box-shadow: 0 0 0 3px rgba(76, 201, 144, 0.35);
+}
+
+.answer-sort-space {
+  width: 40px;
+  height: 40px;
+  display: inline-block;
+  justify-self: center;
 }
 
 textarea {

--- a/mt_aitutor.js
+++ b/mt_aitutor.js
@@ -1,3 +1,37 @@
+const answerLetters = ['a','b','c','d'];
+
+function parseCorrectAnswerLetters(correctValue){
+    const selectedSet = new Set();
+    if(Array.isArray(correctValue)){
+        correctValue.forEach(letter => {
+            if(typeof letter === 'string'){
+                const normalized = letter.toLowerCase();
+                if(answerLetters.includes(normalized)){
+                    selectedSet.add(normalized);
+                }
+            }
+        });
+    }else if(correctValue !== undefined && correctValue !== null){
+        const normalized = String(correctValue);
+        const matches = normalized.match(/[a-d]/gi);
+        if(matches){
+            matches.forEach(letter => selectedSet.add(letter.toLowerCase()));
+        }
+    }
+    return selectedSet;
+}
+
+function escapeHtml(value){
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/\r/g, '&#13;')
+        .replace(/\n/g, '&#10;');
+}
+
 function mt_start_systeem(){
     console.log("go");
 //    document.getElementById("beantwoordknop").innerHTML = 'waiting for answer';
@@ -47,13 +81,18 @@ function mt_verwerk_response(data){
             document.getElementById("kennismatrix").innerHTML += "--<br>";
             document.getElementById("kennismatrix").innerHTML += oudetekst;
 }
-        function mt_beantwoord_vraag(elem, antwoordp, correct){
+        function mt_beantwoord_vraag(elem){
             let titeljouwantwoord = document.getElementById("titeljouwantwoord");
             titeljouwantwoord.innerHTML = 'Wachten op volgende vraag!';
             titeljouwantwoord.style.color = 'red';
+            const antwoordp = elem.dataset.answer || '';
+            const correct = elem.dataset.correct === 'true';
             let buttons = document.getElementsByClassName("antwoordbuttons");
             for(let x = 0; x < buttons.length; x++){
                 buttons[x].onclick = ()=>alert("we wachten op de volgende vraag");
+                if(buttons[x] !== elem && buttons[x].dataset.correct === 'true'){
+                    buttons[x].style.backgroundColor = 'lightgreen';
+                }
             }
             elem.style.backgroundColor = correct ? 'lightgreen' : 'salmon';
             const user_id = document.getElementById("kandidaatnr").value;
@@ -68,13 +107,17 @@ function mt_verwerk_response(data){
 function toonAntwoordKnoppen(data){
     let letters= [data.antwoorda,data.antwoordb,data.antwoordc,data.antwoordd];
     let antwoordletter = ["a", "b", "c", "d"]
+    const correctLetters = parseCorrectAnswerLetters(data.correct_antwoord);
     let returnString = "";
     for(let x = 0; x<4; x++){
-        console.log(data.correct_antwoord)
-        if(letters[x] != "undefined"){
-            returnString += `<div><button class="antwoordbuttons" onclick="mt_beantwoord_vraag(this, '${letters[x]}', ${antwoordletter[x] == data.correct_antwoord})">${antwoordletter[x]}) ${letters[x]}</button></div><br>`
+        const rawAnswer = letters[x];
+        if(rawAnswer !== undefined && rawAnswer !== null && rawAnswer !== "undefined" && rawAnswer !== ""){
+            const letter = antwoordletter[x];
+            const isCorrect = correctLetters.has(letter);
+            const safeAnswer = escapeHtml(rawAnswer);
+            returnString += `<div><button class="antwoordbuttons" data-letter="${letter}" data-answer="${safeAnswer}" data-correct="${isCorrect}" onclick="mt_beantwoord_vraag(this)">${letter}) ${safeAnswer}</button></div><br>`;
         }
-    }    
+    }
     return returnString;
 }
 function maakrapportage(){

--- a/vrageneditor/index.html
+++ b/vrageneditor/index.html
@@ -22,10 +22,10 @@
         <h2>Vraag</h2>
         <textarea id="vraag" cols="150" rows="6"></textarea>
         <br><br>
-        <input id="antwoorda" size="150"><input id="checkboxa" type=checkbox><button>v</button><br>
-        <input id="antwoordb" size="150"><input id="checkboxb" type=checkbox><button>^</button><button>v</button><br>
-        <input id="antwoordc" size="150"><input id="checkboxc" type=checkbox><button>^</button><button>v</button><br>
-        <input id="antwoordd" size="150"><input id="checkboxd" type=checkbox><button>^</button>
+        <input id="antwoorda" size="150"><input id="checkboxa" type=checkbox onclick="setCorrectAnswer('a')"><button type="button" onclick="moveAnswer('a','down')">v</button><br>
+        <input id="antwoordb" size="150"><input id="checkboxb" type=checkbox onclick="setCorrectAnswer('b')"><button type="button" onclick="moveAnswer('b','up')">^</button><button type="button" onclick="moveAnswer('b','down')">v</button><br>
+        <input id="antwoordc" size="150"><input id="checkboxc" type=checkbox onclick="setCorrectAnswer('c')"><button type="button" onclick="moveAnswer('c','up')">^</button><button type="button" onclick="moveAnswer('c','down')">v</button><br>
+        <input id="antwoordd" size="150"><input id="checkboxd" type=checkbox onclick="setCorrectAnswer('d')"><button type="button" onclick="moveAnswer('d','up')">^</button>
         <textarea id="toelichting" cols="150" rows="6"></textarea>
         <input hidden id="juistantwoord">
         <div id="toelichtingsdiv">
@@ -39,6 +39,7 @@
     </div>
         <script src="../aitutor.js"></script>
         <script>
+            const answerLetters = ['a','b','c','d'];
             let opleidingsnr = new URLSearchParams(window.location.search).get("opleidingsnummer");
             fetch(server+"/get_opleidingnaam_via_id/"+opleidingsnr)
             .then(r=>r.text())
@@ -47,6 +48,57 @@
             .then(r=>r.text())
             .then(d=>toonallevragenvanopleiding(d))
             document.getElementById("toelichtingsdiv").hidden = true;
+            function moveAnswer(letter, direction){
+                const currentIndex = answerLetters.indexOf(letter);
+                const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
+                if (targetIndex < 0 || targetIndex >= answerLetters.length){
+                    return;
+                }
+                const targetLetter = answerLetters[targetIndex];
+                const currentInput = document.getElementById('antwoord'+letter);
+                const targetInput = document.getElementById('antwoord'+targetLetter);
+                const currentCheckbox = document.getElementById('checkbox'+letter);
+                const targetCheckbox = document.getElementById('checkbox'+targetLetter);
+
+                const tempValue = currentInput.value;
+                currentInput.value = targetInput.value;
+                targetInput.value = tempValue;
+
+                const tempChecked = currentCheckbox.checked;
+                currentCheckbox.checked = targetCheckbox.checked;
+                targetCheckbox.checked = tempChecked;
+
+                updateCorrectAnswerFromCheckbox();
+            }
+            function setCorrectAnswer(letter){
+                const validLetter = answerLetters.includes(letter);
+                answerLetters.forEach(l => {
+                    const checkbox = document.getElementById('checkbox'+l);
+                    const input = document.getElementById('antwoord'+l);
+                    if(validLetter && l === letter){
+                        checkbox.checked = true;
+                        input.style.backgroundColor = 'lightgreen';
+                    }else{
+                        checkbox.checked = false;
+                        input.style.backgroundColor = 'white';
+                    }
+                });
+                document.getElementById('juistantwoord').value = validLetter ? letter : '';
+            }
+            function updateCorrectAnswerFromCheckbox(){
+                let selectedLetter = '';
+                answerLetters.forEach(letter => {
+                    const checkbox = document.getElementById('checkbox'+letter);
+                    if(selectedLetter === '' && checkbox.checked){
+                        selectedLetter = letter;
+                    }
+                });
+                if(selectedLetter !== ''){
+                    setCorrectAnswer(selectedLetter);
+                }else{
+                    setCorrectAnswer('');
+                }
+            }
             function maakvraagaan(){
                 verzendObject = {}
                 verzendObject.opleidingsnr = document.getElementById("opleidingsnr").value;
@@ -65,10 +117,6 @@
                 document.getElementById("toelichtingsdiv").hidden = false;
                 document.getElementById("maakvraagknop").disabled = false;
                 document.getElementById("maakvraagknop").innerHTML = 'verzin nieuwe vraag';
-                document.getElementById("antwoorda").style.backgroundColor = "white";
-                document.getElementById("antwoordb").style.backgroundColor = "white";
-                document.getElementById("antwoordc").style.backgroundColor = "white";
-                document.getElementById("antwoordd").style.backgroundColor = "white";
                 document.getElementById("vraag").value = data.vraag;
                 document.getElementById("antwoorda").value = data.antwoorda;
                 document.getElementById("antwoordb").value = data.antwoordb;
@@ -76,8 +124,7 @@
                 document.getElementById("antwoordd").value = data.antwoordd;
                 document.getElementById("juistantwoord").value = data.juistantwoord;
                 document.getElementById("toelichting").value = data.toelichting;
-                document.getElementById("antwoord"+data.juistantwoord).style.backgroundColor = "lightgreen";
-                document.getElementById("checkbox"+data.juistantwoord).checked = true;
+                setCorrectAnswer(data.juistantwoord);
             }
             function slavraagop(){
                 console.log("sla vraag op")

--- a/vrageneditor/index.html
+++ b/vrageneditor/index.html
@@ -28,9 +28,8 @@
                 <input id="checkboxa" type="checkbox" onclick="toggleCorrectAnswer('a')">
                 <span class="answer-checkbox-box">&#10003;</span>
             </label>
-            <div class="answer-controls">
-                <button type="button" class="answer-sort-button" onclick="moveAnswer('a','down')" aria-label="Verplaats antwoord A omlaag">&#9660;</button>
-            </div>
+            <span class="answer-sort-space" aria-hidden="true"></span>
+            <button type="button" class="answer-sort-button" onclick="moveAnswer('a','down')" aria-label="Verplaats antwoord A omlaag">&#9660;</button>
         </div>
         <div class="answer-row" id="answer-row-b">
             <input id="antwoordb" class="answer-input">
@@ -38,10 +37,8 @@
                 <input id="checkboxb" type="checkbox" onclick="toggleCorrectAnswer('b')">
                 <span class="answer-checkbox-box">&#10003;</span>
             </label>
-            <div class="answer-controls">
-                <button type="button" class="answer-sort-button" onclick="moveAnswer('b','up')" aria-label="Verplaats antwoord B omhoog">&#9650;</button>
-                <button type="button" class="answer-sort-button" onclick="moveAnswer('b','down')" aria-label="Verplaats antwoord B omlaag">&#9660;</button>
-            </div>
+            <button type="button" class="answer-sort-button" onclick="moveAnswer('b','up')" aria-label="Verplaats antwoord B omhoog">&#9650;</button>
+            <button type="button" class="answer-sort-button" onclick="moveAnswer('b','down')" aria-label="Verplaats antwoord B omlaag">&#9660;</button>
         </div>
         <div class="answer-row" id="answer-row-c">
             <input id="antwoordc" class="answer-input">
@@ -49,10 +46,8 @@
                 <input id="checkboxc" type="checkbox" onclick="toggleCorrectAnswer('c')">
                 <span class="answer-checkbox-box">&#10003;</span>
             </label>
-            <div class="answer-controls">
-                <button type="button" class="answer-sort-button" onclick="moveAnswer('c','up')" aria-label="Verplaats antwoord C omhoog">&#9650;</button>
-                <button type="button" class="answer-sort-button" onclick="moveAnswer('c','down')" aria-label="Verplaats antwoord C omlaag">&#9660;</button>
-            </div>
+            <button type="button" class="answer-sort-button" onclick="moveAnswer('c','up')" aria-label="Verplaats antwoord C omhoog">&#9650;</button>
+            <button type="button" class="answer-sort-button" onclick="moveAnswer('c','down')" aria-label="Verplaats antwoord C omlaag">&#9660;</button>
         </div>
         <div class="answer-row" id="answer-row-d">
             <input id="antwoordd" class="answer-input">
@@ -60,9 +55,8 @@
                 <input id="checkboxd" type="checkbox" onclick="toggleCorrectAnswer('d')">
                 <span class="answer-checkbox-box">&#10003;</span>
             </label>
-            <div class="answer-controls">
-                <button type="button" class="answer-sort-button" onclick="moveAnswer('d','up')" aria-label="Verplaats antwoord D omhoog">&#9650;</button>
-            </div>
+            <button type="button" class="answer-sort-button" onclick="moveAnswer('d','up')" aria-label="Verplaats antwoord D omhoog">&#9650;</button>
+            <span class="answer-sort-space" aria-hidden="true"></span>
         </div>
         <textarea id="toelichting" cols="150" rows="6"></textarea>
         <input hidden id="juistantwoord">

--- a/vrageneditor/index.html
+++ b/vrageneditor/index.html
@@ -22,10 +22,10 @@
         <h2>Vraag</h2>
         <textarea id="vraag" cols="150" rows="6"></textarea>
         <br><br>
-        <input id="antwoorda" size="150"><input id="checkboxa" type=checkbox onclick="setCorrectAnswer('a')"><button type="button" onclick="moveAnswer('a','down')">v</button><br>
-        <input id="antwoordb" size="150"><input id="checkboxb" type=checkbox onclick="setCorrectAnswer('b')"><button type="button" onclick="moveAnswer('b','up')">^</button><button type="button" onclick="moveAnswer('b','down')">v</button><br>
-        <input id="antwoordc" size="150"><input id="checkboxc" type=checkbox onclick="setCorrectAnswer('c')"><button type="button" onclick="moveAnswer('c','up')">^</button><button type="button" onclick="moveAnswer('c','down')">v</button><br>
-        <input id="antwoordd" size="150"><input id="checkboxd" type=checkbox onclick="setCorrectAnswer('d')"><button type="button" onclick="moveAnswer('d','up')">^</button>
+        <input id="antwoorda" size="150"><input id="checkboxa" type=checkbox onclick="toggleCorrectAnswer('a')"><button type="button" onclick="moveAnswer('a','down')">v</button><br>
+        <input id="antwoordb" size="150"><input id="checkboxb" type=checkbox onclick="toggleCorrectAnswer('b')"><button type="button" onclick="moveAnswer('b','up')">^</button><button type="button" onclick="moveAnswer('b','down')">v</button><br>
+        <input id="antwoordc" size="150"><input id="checkboxc" type=checkbox onclick="toggleCorrectAnswer('c')"><button type="button" onclick="moveAnswer('c','up')">^</button><button type="button" onclick="moveAnswer('c','down')">v</button><br>
+        <input id="antwoordd" size="150"><input id="checkboxd" type=checkbox onclick="toggleCorrectAnswer('d')"><button type="button" onclick="moveAnswer('d','up')">^</button>
         <textarea id="toelichting" cols="150" rows="6"></textarea>
         <input hidden id="juistantwoord">
         <div id="toelichtingsdiv">
@@ -68,36 +68,51 @@
                 currentCheckbox.checked = targetCheckbox.checked;
                 targetCheckbox.checked = tempChecked;
 
-                updateCorrectAnswerFromCheckbox();
+                syncCorrectAnswers();
             }
-            function setCorrectAnswer(letter){
-                const validLetter = answerLetters.includes(letter);
-                answerLetters.forEach(l => {
-                    const checkbox = document.getElementById('checkbox'+l);
-                    const input = document.getElementById('antwoord'+l);
-                    if(validLetter && l === letter){
-                        checkbox.checked = true;
+            function toggleCorrectAnswer(letter){
+                if(!answerLetters.includes(letter)){
+                    return;
+                }
+                syncCorrectAnswers();
+            }
+            function syncCorrectAnswers(){
+                const selectedLetters = [];
+                answerLetters.forEach(letter => {
+                    const checkbox = document.getElementById('checkbox'+letter);
+                    const input = document.getElementById('antwoord'+letter);
+                    if(checkbox.checked){
                         input.style.backgroundColor = 'lightgreen';
+                        selectedLetters.push(letter);
                     }else{
-                        checkbox.checked = false;
                         input.style.backgroundColor = 'white';
                     }
                 });
-                document.getElementById('juistantwoord').value = validLetter ? letter : '';
+                document.getElementById('juistantwoord').value = selectedLetters.join(',');
             }
-            function updateCorrectAnswerFromCheckbox(){
-                let selectedLetter = '';
+            function parseCorrectAnswerLetters(correctValue){
+                const selectedSet = new Set();
+                if(Array.isArray(correctValue)){
+                    correctValue.forEach(letter => {
+                        if(answerLetters.includes(letter)){
+                            selectedSet.add(letter);
+                        }
+                    });
+                }else if(typeof correctValue === 'string'){
+                    const matches = correctValue.match(/[a-d]/g);
+                    if(matches){
+                        matches.forEach(letter => selectedSet.add(letter));
+                    }
+                }
+                return selectedSet;
+            }
+            function applyCorrectAnswers(correctValue){
+                const selectedSet = parseCorrectAnswerLetters(correctValue);
                 answerLetters.forEach(letter => {
                     const checkbox = document.getElementById('checkbox'+letter);
-                    if(selectedLetter === '' && checkbox.checked){
-                        selectedLetter = letter;
-                    }
+                    checkbox.checked = selectedSet.has(letter);
                 });
-                if(selectedLetter !== ''){
-                    setCorrectAnswer(selectedLetter);
-                }else{
-                    setCorrectAnswer('');
-                }
+                syncCorrectAnswers();
             }
             function maakvraagaan(){
                 verzendObject = {}
@@ -122,9 +137,8 @@
                 document.getElementById("antwoordb").value = data.antwoordb;
                 document.getElementById("antwoordc").value = data.antwoordc;
                 document.getElementById("antwoordd").value = data.antwoordd;
-                document.getElementById("juistantwoord").value = data.juistantwoord;
                 document.getElementById("toelichting").value = data.toelichting;
-                setCorrectAnswer(data.juistantwoord);
+                applyCorrectAnswers(data.juistantwoord);
             }
             function slavraagop(){
                 console.log("sla vraag op")
@@ -154,16 +168,15 @@
     lijstDiv.innerHTML = '';
     allevragen.forEach((vraag, index) => {
         const card = document.createElement('div');
-        // neem de tekst van de correcte optie uit vraag.correct_antwoord
-        const correct = vraag.correct_antwoord;
+        const correctLetters = parseCorrectAnswerLetters(vraag.correct_antwoord);
         card.innerHTML = `
           <hr>
           <details>
           <summary><strong>${vraag.vraag}</strong> - <button onclick=verwijdervraag(${vraag.id})>verwijder</button></summary>
-          <p class="${"a" === correct ? 'correct-answer' : ''}">a) ${vraag.antwoorda}</p>
-          <p class="${"b" === correct ? 'correct-answer' : ''}">b) ${vraag.antwoordb}</p>
-          <p class="${"c" === correct ? 'correct-answer' : ''}">c) ${vraag.antwoordc}</p>
-          <p class="${"d" === correct ? 'correct-answer' : ''}">d) ${vraag.antwoordd}</p>
+          <p class="${correctLetters.has('a') ? 'correct-answer' : ''}">a) ${vraag.antwoorda}</p>
+          <p class="${correctLetters.has('b') ? 'correct-answer' : ''}">b) ${vraag.antwoordb}</p>
+          <p class="${correctLetters.has('c') ? 'correct-answer' : ''}">c) ${vraag.antwoordc}</p>
+          <p class="${correctLetters.has('d') ? 'correct-answer' : ''}">d) ${vraag.antwoordd}</p>
           <h5>Toelichting:</h5>
           <div class="explanation">${vraag.toelichting || ''}</div>
           </details>

--- a/vrageneditor/index.html
+++ b/vrageneditor/index.html
@@ -22,10 +22,48 @@
         <h2>Vraag</h2>
         <textarea id="vraag" cols="150" rows="6"></textarea>
         <br><br>
-        <input id="antwoorda" size="150"><input id="checkboxa" type=checkbox onclick="toggleCorrectAnswer('a')"><button type="button" onclick="moveAnswer('a','down')">v</button><br>
-        <input id="antwoordb" size="150"><input id="checkboxb" type=checkbox onclick="toggleCorrectAnswer('b')"><button type="button" onclick="moveAnswer('b','up')">^</button><button type="button" onclick="moveAnswer('b','down')">v</button><br>
-        <input id="antwoordc" size="150"><input id="checkboxc" type=checkbox onclick="toggleCorrectAnswer('c')"><button type="button" onclick="moveAnswer('c','up')">^</button><button type="button" onclick="moveAnswer('c','down')">v</button><br>
-        <input id="antwoordd" size="150"><input id="checkboxd" type=checkbox onclick="toggleCorrectAnswer('d')"><button type="button" onclick="moveAnswer('d','up')">^</button>
+        <div class="answer-row" id="answer-row-a">
+            <input id="antwoorda" class="answer-input">
+            <label class="answer-checkbox" aria-label="Markeer antwoord A als correct">
+                <input id="checkboxa" type="checkbox" onclick="toggleCorrectAnswer('a')">
+                <span class="answer-checkbox-box">&#10003;</span>
+            </label>
+            <div class="answer-controls">
+                <button type="button" class="answer-sort-button" onclick="moveAnswer('a','down')" aria-label="Verplaats antwoord A omlaag">&#9660;</button>
+            </div>
+        </div>
+        <div class="answer-row" id="answer-row-b">
+            <input id="antwoordb" class="answer-input">
+            <label class="answer-checkbox" aria-label="Markeer antwoord B als correct">
+                <input id="checkboxb" type="checkbox" onclick="toggleCorrectAnswer('b')">
+                <span class="answer-checkbox-box">&#10003;</span>
+            </label>
+            <div class="answer-controls">
+                <button type="button" class="answer-sort-button" onclick="moveAnswer('b','up')" aria-label="Verplaats antwoord B omhoog">&#9650;</button>
+                <button type="button" class="answer-sort-button" onclick="moveAnswer('b','down')" aria-label="Verplaats antwoord B omlaag">&#9660;</button>
+            </div>
+        </div>
+        <div class="answer-row" id="answer-row-c">
+            <input id="antwoordc" class="answer-input">
+            <label class="answer-checkbox" aria-label="Markeer antwoord C als correct">
+                <input id="checkboxc" type="checkbox" onclick="toggleCorrectAnswer('c')">
+                <span class="answer-checkbox-box">&#10003;</span>
+            </label>
+            <div class="answer-controls">
+                <button type="button" class="answer-sort-button" onclick="moveAnswer('c','up')" aria-label="Verplaats antwoord C omhoog">&#9650;</button>
+                <button type="button" class="answer-sort-button" onclick="moveAnswer('c','down')" aria-label="Verplaats antwoord C omlaag">&#9660;</button>
+            </div>
+        </div>
+        <div class="answer-row" id="answer-row-d">
+            <input id="antwoordd" class="answer-input">
+            <label class="answer-checkbox" aria-label="Markeer antwoord D als correct">
+                <input id="checkboxd" type="checkbox" onclick="toggleCorrectAnswer('d')">
+                <span class="answer-checkbox-box">&#10003;</span>
+            </label>
+            <div class="answer-controls">
+                <button type="button" class="answer-sort-button" onclick="moveAnswer('d','up')" aria-label="Verplaats antwoord D omhoog">&#9650;</button>
+            </div>
+        </div>
         <textarea id="toelichting" cols="150" rows="6"></textarea>
         <input hidden id="juistantwoord">
         <div id="toelichtingsdiv">
@@ -80,12 +118,14 @@
                 const selectedLetters = [];
                 answerLetters.forEach(letter => {
                     const checkbox = document.getElementById('checkbox'+letter);
-                    const input = document.getElementById('antwoord'+letter);
-                    if(checkbox.checked){
-                        input.style.backgroundColor = 'lightgreen';
+                    const row = document.getElementById('answer-row-'+letter);
+                    if(checkbox && checkbox.checked){
+                        if(row){
+                            row.classList.add('answer-row--correct');
+                        }
                         selectedLetters.push(letter);
-                    }else{
-                        input.style.backgroundColor = 'white';
+                    }else if(row){
+                        row.classList.remove('answer-row--correct');
                     }
                 });
                 const correctField = document.getElementById('juistantwoord');

--- a/vrageneditor/index.html
+++ b/vrageneditor/index.html
@@ -88,7 +88,8 @@
                         input.style.backgroundColor = 'white';
                     }
                 });
-                document.getElementById('juistantwoord').value = selectedLetters.join(',');
+                const correctField = document.getElementById('juistantwoord');
+                correctField.value = String(selectedLetters.join(','));
             }
             function parseCorrectAnswerLetters(correctValue){
                 const selectedSet = new Set();
@@ -98,10 +99,11 @@
                             selectedSet.add(letter);
                         }
                     });
-                }else if(typeof correctValue === 'string'){
-                    const matches = correctValue.match(/[a-d]/g);
+                }else if(correctValue !== undefined && correctValue !== null){
+                    const normalized = String(correctValue);
+                    const matches = normalized.match(/[a-d]/gi);
                     if(matches){
-                        matches.forEach(letter => selectedSet.add(letter));
+                        matches.forEach(letter => selectedSet.add(letter.toLowerCase()));
                     }
                 }
                 return selectedSet;
@@ -146,7 +148,7 @@
                 verzendObject.opleidingsnr  = opleidingsnr;
                 verzendObject.vraagsoort    = document.getElementById("vraagsoort").value;
                 verzendObject.niveau        = document.getElementById("niveau").value;
-                verzendObject.juistantwoord = document.getElementById("juistantwoord").value;
+                verzendObject.juistantwoord = String(document.getElementById("juistantwoord").value || '');
                 verzendObject.vraag         = document.getElementById("vraag").value;
                 verzendObject.antwoorda     = document.getElementById("antwoorda").value;
                 verzendObject.antwoordb     = document.getElementById("antwoordb").value;
@@ -190,7 +192,7 @@
                 verzendObject.opleidingsnr  = opleidingsnr;
                 verzendObject.vraagsoort    = document.getElementById("vraagsoort").value;
                 verzendObject.niveau        = document.getElementById("niveau").value;
-                verzendObject.juistantwoord = document.getElementById("juistantwoord").value;
+                verzendObject.juistantwoord = String(document.getElementById("juistantwoord").value || '');
                 verzendObject.vraag         = document.getElementById("vraag").value;
                 verzendObject.antwoorda     = document.getElementById("antwoorda").value;
                 verzendObject.antwoordb     = document.getElementById("antwoordb").value;


### PR DESCRIPTION
## Summary
- wire the up/down controls to swap answer text and checkbox state in place
- centralize correct-answer handling so highlighting and the hidden field stay in sync after reordering
- allow instructors to click a checkbox to set the correct option manually

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d30d7dcc8c8320bd9d349d70f9b8a1