### PR TITLE
Add Vier op een Rij webspel

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vier op een Rij</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="app__header">
+        <h1>Vier op een Rij</h1>
+        <p class="app__description">
+          Laat de schijven vallen en probeer vier op een rij te krijgen voordat je tegenstander dat doet!
+        </p>
+      </header>
+
+      <section class="status">
+        <p id="turn-indicator" class="status__indicator" aria-live="polite"></p>
+        <button id="reset-button" class="status__reset" type="button">Nieuw spel</button>
+      </section>
+
+      <section class="board" aria-label="Speelbord">
+        <div id="board" class="board__grid" role="grid"></div>
+      </section>
+    </main>
+
+    <template id="cell-template">
+      <button class="cell" role="gridcell" aria-label="Lege cel" data-column></button>
+    </template>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,171 @@
+const ROWS = 6;
+const COLS = 7;
+const boardElement = document.getElementById("board");
+const cellTemplate = document.getElementById("cell-template");
+const turnIndicator = document.getElementById("turn-indicator");
+const resetButton = document.getElementById("reset-button");
+
+let boardState;
+let currentPlayer;
+let gameOver;
+
+function createEmptyBoard() {
+  return Array.from({ length: ROWS }, () => Array(COLS).fill(0));
+}
+
+function setupBoard() {
+  boardElement.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+
+  for (let row = 0; row < ROWS; row += 1) {
+    for (let col = 0; col < COLS; col += 1) {
+      const cell = cellTemplate.content.firstElementChild.cloneNode(true);
+      cell.dataset.row = row;
+      cell.dataset.column = col;
+      cell.addEventListener("click", () => handleMove(col));
+      cell.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          handleMove(col);
+        }
+      });
+      fragment.append(cell);
+    }
+  }
+
+  boardElement.append(fragment);
+}
+
+function updateTurnIndicator(message) {
+  if (message) {
+    turnIndicator.textContent = message;
+    return;
+  }
+
+  const playerName = currentPlayer === 1 ? "Rood" : "Geel";
+  turnIndicator.textContent = `Beurt: speler ${playerName}`;
+}
+
+function handleMove(column) {
+  if (gameOver) return;
+
+  const columnCells = [];
+  for (let row = ROWS - 1; row >= 0; row -= 1) {
+    if (boardState[row][column] === 0) {
+      columnCells.push(row);
+    }
+  }
+
+  const targetRow = columnCells[0];
+
+  if (targetRow === undefined) {
+    updateTurnIndicator("Deze kolom is vol, kies een andere.");
+    setTimeout(() => updateTurnIndicator(), 1500);
+    return;
+  }
+
+  boardState[targetRow][column] = currentPlayer;
+  paintBoard();
+
+  const winningCells = checkWin(targetRow, column);
+  if (winningCells) {
+    highlightWinningCells(winningCells);
+    updateTurnIndicator(`Speler ${currentPlayer === 1 ? "Rood" : "Geel"} wint!`);
+    gameOver = true;
+    return;
+  }
+
+  if (isBoardFull()) {
+    updateTurnIndicator("Gelijkspel! Het bord is vol.");
+    gameOver = true;
+    return;
+  }
+
+  currentPlayer = currentPlayer === 1 ? 2 : 1;
+  updateTurnIndicator();
+}
+
+function paintBoard() {
+  const cells = boardElement.querySelectorAll(".cell");
+  cells.forEach((cell) => {
+    const row = Number(cell.dataset.row);
+    const col = Number(cell.dataset.column);
+    const value = boardState[row][col];
+
+    cell.dataset.player = value ? String(value) : "";
+    cell.removeAttribute("data-win");
+    cell.ariaLabel = value
+      ? `Cel (${row + 1}, ${col + 1}) bezet door speler ${value === 1 ? "Rood" : "Geel"}`
+      : `Lege cel (${row + 1}, ${col + 1})`;
+  });
+}
+
+function isBoardFull() {
+  return boardState.every((row) => row.every((cell) => cell !== 0));
+}
+
+function directions() {
+  return [
+    [0, 1],
+    [1, 0],
+    [1, 1],
+    [1, -1],
+  ];
+}
+
+function checkWin(row, col) {
+  const player = boardState[row][col];
+
+  for (const [dx, dy] of directions()) {
+    const cells = [[row, col]];
+
+    let r = row + dx;
+    let c = col + dy;
+    while (isInside(r, c) && boardState[r][c] === player) {
+      cells.push([r, c]);
+      r += dx;
+      c += dy;
+    }
+
+    r = row - dx;
+    c = col - dy;
+    while (isInside(r, c) && boardState[r][c] === player) {
+      cells.unshift([r, c]);
+      r -= dx;
+      c -= dy;
+    }
+
+    if (cells.length >= 4) {
+      return cells;
+    }
+  }
+
+  return null;
+}
+
+function isInside(row, col) {
+  return row >= 0 && row < ROWS && col >= 0 && col < COLS;
+}
+
+function highlightWinningCells(cells) {
+  cells.forEach(([row, col]) => {
+    const selector = `.cell[data-row="${row}"][data-column="${col}"]`;
+    const cell = boardElement.querySelector(selector);
+    if (cell) {
+      cell.dataset.win = "true";
+    }
+  });
+}
+
+function resetGame() {
+  boardState = createEmptyBoard();
+  currentPlayer = 1;
+  gameOver = false;
+  paintBoard();
+  updateTurnIndicator();
+}
+
+resetButton.addEventListener("click", resetGame);
+
+setupBoard();
+resetGame();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,152 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --bg: #0d1b2a;
+  --panel: rgba(255, 255, 255, 0.12);
+  --text: #f1f5f9;
+  --yellow: #facc15;
+  --red: #f87171;
+  --blue: #0ea5e9;
+  --board-bg: rgba(14, 165, 233, 0.2);
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem;
+}
+
+.app {
+  width: min(90vw, 640px);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.app__header {
+  text-align: center;
+}
+
+.app__description {
+  margin-top: 0.25rem;
+  color: rgba(241, 245, 249, 0.75);
+}
+
+.status {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: var(--panel);
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.25);
+}
+
+.status__indicator {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.status__reset {
+  padding: 0.5rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--blue);
+  color: #0f172a;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.status__reset:hover,
+.status__reset:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 30px rgba(14, 165, 233, 0.35);
+}
+
+.board {
+  background: var(--board-bg);
+  padding: 1.5rem;
+  border-radius: 1.5rem;
+  box-shadow: inset 0 0 20px rgba(15, 23, 42, 0.4), 0 25px 45px rgba(15, 23, 42, 0.35);
+}
+
+.board__grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.cell {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  border: none;
+  background: rgba(15, 23, 42, 0.35);
+  box-shadow: inset 0 12px 18px rgba(0, 0, 0, 0.35);
+  cursor: pointer;
+  position: relative;
+  transition: transform 0.15s ease;
+}
+
+.cell::after {
+  content: "";
+  position: absolute;
+  inset: 12%;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.2);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.cell:hover::after,
+.cell:focus-visible::after {
+  opacity: 1;
+}
+
+.cell[data-player="1"] {
+  background: radial-gradient(circle at 30% 30%, #fff8, #0000 60%), var(--red);
+}
+
+.cell[data-player="2"] {
+  background: radial-gradient(circle at 30% 30%, #fff8, #0000 60%), var(--yellow);
+}
+
+.cell[data-win="true"] {
+  outline: 4px solid #fef3c7;
+  outline-offset: 4px;
+  animation: pulse 1s infinite alternate ease-in-out;
+}
+
+@keyframes pulse {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(1.05);
+  }
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 1.5rem 0.75rem;
+  }
+
+  .status {
+    justify-content: center;
+  }
+
+  .status__reset {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone Vier op een Rij pagina met bord, statusindicator en resetknop
- style het bord en de knoppen met moderne kleurstelling en animaties
- implementeer spelmechanica in JavaScript inclusief beurtwisseling, winstdetectie en reset

## Testing
- niet uitgevoerd (niet van toepassing)


------
https://chatgpt.com/codex/tasks/task_e_68d65f30b4d08320804b95e23ec354cc